### PR TITLE
fix/XACCEL-1909 "Metadata Fields":  Handles multiple campus units

### DIFF
--- a/global/js/helpers/metadata-fields/basicMetadata.js
+++ b/global/js/helpers/metadata-fields/basicMetadata.js
@@ -141,15 +141,19 @@ export function basicMetadata({ data }) {
         </div>
       ` : ''}
 
-      ${campus && !["undefined", undefined, null, ""].includes(campus.asset_assetid) ? `
+      ${campus && campus.length ? `
         <div class="su-border-t border-t-black-20">
           ${basicField({
-            title: "Campus unit",
-            children: `
-              <a href="${campus.asset_url}" class="su-no-underline su-leading-snug hover:su-underline su-text-digital-red dark:su-text-dark-mode-red dark:hover:su-text-white hover:su-text-black su-text-18">
-                ${campus.asset_name}
-              </a>
-            `
+            title: `Campus unit${campus.length > 1 ? "s" : ""}`,
+            children: campus.map((item) => `
+
+            ${!["undefined", undefined, null, ""].includes(item.asset_assetid) ? `
+              <div class="" key="${item.asset_assetid}">
+                <a href="${item.asset_url}" class="su-no-underline su-leading-snug hover:su-underline su-text-digital-red dark:su-text-dark-mode-red dark:hover:su-text-white hover:su-text-black su-text-18">
+                  ${item.asset_name}
+                </a>
+              </div>` : ``}
+            `).join('')
           })}
         </div>
       ` : ''}

--- a/packages/metadata-fields/main.spec.js
+++ b/packages/metadata-fields/main.spec.js
@@ -191,6 +191,27 @@ describe('[Metadata Fields]', () => {
                     
 
                     
+                      <div class="su-border-t border-t-black-20">
+                        
+                  <div class="su-flex su-flex-col su-gap-27 su-pt-32 su-pb-22 md:su-pt-45 md:su-pt-36 su-justify-left">
+                    <h3 class="su-text-23 su-font-bold su-leading-[27.6px] su-font-sans !su-m-0">
+                      Campus unit
+                    </h3>
+                    <div class="su-flex su-flex-col su-gap-6 su-text-21 ">
+                      
+
+                          
+                            <div class="" key="28349">
+                              <a href="https://news.stanford.edu/featured-unit/stanford-graduate-school-of-education" class="su-no-underline su-leading-snug hover:su-underline su-text-digital-red dark:su-text-dark-mode-red dark:hover:su-text-white hover:su-text-black su-text-18">
+                                Stanford Graduate School of Education
+                              </a>
+                            </div>
+                          
+                    </div>
+                  </div>
+                
+                      </div>
+                    
 
                     
                       <div class="su-border-t border-t-black-20">

--- a/packages/metadata-fields/manifest.json
+++ b/packages/metadata-fields/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "metadata-fields",
     "type": "edge",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "namespace": "pnp-stanford-edge-components-hbs",
     "description": "This is a global element that is designed to render client side based on page information.",
     "displayName": "Metadata fields",


### PR DESCRIPTION
Updates the display of campus units to handle scenarios where multiple units are associated with an asset.

The change maps over the campus array and displays each campus unit with a link to its asset URL.

Also, updates the manifest version.