### PR TITLE
Fix/xaccel 2085 "Stories carousel"

### DIFF
--- a/packages/stories-carousel/main.js
+++ b/packages/stories-carousel/main.js
@@ -1,7 +1,6 @@
-import hash from "object-hash";
 import storiesCarouselTemplate from './stories-carousel.hbs';
 import { linkedHeadingService, uuid } from "../../global/js/utils";
-import { Carousel, Card, Modal, EmbedVideo } from "../../global/js/helpers";
+import { Carousel, Card } from "../../global/js/helpers";
 import { fetchUserStories } from "../../global/js/utils/fetchUserStories";
 
 /**
@@ -210,26 +209,29 @@ export default {
         }
 
         const cardData = [];
-        const cardModal = [];
+        const modalData = [];
         let uniqueClass = ""
         
         if (data !== null && data !== undefined) {
             uniqueClass = uuid();
             
             data.forEach((card) => {
+                const uniqueID = uuid();
                 cardData.push(
                     `<div class="swiper-slide">
-                        ${Card({data: card, displayDescription: false})}
+                        ${Card({data: card, displayDescription: false, uniqueId: uniqueID})}
                     </div>`
                 );
 
-                if (card.type === 'Video') {
-                    const uniqueId = hash.MD5(
-                        JSON.stringify(card.videoUrl) + hash.MD5(JSON.stringify(card.title))
-                    );
-                    cardModal.push(
-                        Modal({content: EmbedVideo({ isVertical: card.size === "vertical-video", videoId: card.videoUrl, title: `Watch ${card.title}`, noAutoPlay: true }), uniqueId, describedby: 'card-modal' })
-                    );
+                if (card.type === 'Video' || card.videoUrl) {
+                    modalData.push({
+                        isVertical: card.size === "vertical-video",
+                        videoId: card.videoUrl,
+                        title: `Watch ${card.title}`, 
+                        noAutoPlay: true,
+                        uniqueID: uniqueID,
+                        titleID: 'card-modal'
+                    })
                 }
             });
         }
@@ -255,7 +257,7 @@ export default {
             ctaNewWindow: headingData.ctaNewWindow,
             ctaText: headingData.ctaText,
             carousel: Carousel({ variant:"cards", slides: cardData.join(''), uniqueClass: uniqueClass }),
-            cardModal: cardModal.join(''),
+            modalData,
             width: "large",
             dataSource,
             query

--- a/packages/stories-carousel/manifest.json
+++ b/packages/stories-carousel/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "stories-carousel",
     "type": "edge",
-    "version": "4.0.9",
+    "version": "4.0.10",
     "namespace": "pnp-stanford-edge-components-hbs",
     "description": "Links to stories displayed as cards in a carousel.",
     "displayName": "Stories carousel",
@@ -81,9 +81,7 @@
                         "title": "Grid Content",
                         "description": "The cards to display in the carousel area of the component.",
                         "type": "object",
-                        "required": [
-                            "searchQuery"
-                        ],
+                        "required": ["searchQuery"],
                         "properties": {
                             "searchQuery": {
                                 "type": "string",

--- a/packages/stories-carousel/stories-carousel.hbs
+++ b/packages/stories-carousel/stories-carousel.hbs
@@ -3,5 +3,11 @@
         {{> linked-heading title=title isAlwaysLight=isAlwaysLight ctaLink=ctaLink ctaNewWindow=ctaNewWindow ctaText=ctaText}}
         {{{carousel}}}
     </div>
-    {{{cardModal}}}
+    <section data-element="modal-wrapper">
+    {{#each modalData}}
+        {{#> modal-content uniqueID=uniqueID titleID='card-modal' ariaTitle=title}}
+            {{> embed-video isVertical=isVertical classes=classes videoId=videoId noAutoPlay=noAutoPlay title=title}}
+        {{/ modal-content}}
+    {{/each}}
+    </section>
 </section>


### PR DESCRIPTION
Updates the stories carousel component to handle modal content more efficiently.

This change streamlines the process of generating modals for video cards within the carousel. It consolidates modal data and simplifies the template rendering, resulting in cleaner and more maintainable code. It also removes an unused dependency.
