### PR TITLE
Fixed casing on svg icon

### DIFF
--- a/global/hbs/icons/icon-add/icon-add.hbs
+++ b/global/hbs/icons/icon-add/icon-add.hbs
@@ -9,8 +9,8 @@
     <path
         fill='transparent'
         d='M22 16.5V22M22 22V27.5M22 22H27.5M22 22H16.5M38.5 22C38.5 31.1127 31.1127 38.5 22 38.5C12.8873 38.5 5.5 31.1127 5.5 22C5.5 12.8873 12.8873 5.5 22 5.5C31.1127 5.5 38.5 12.8873 38.5 22Z'
-        strokeWidth='2'
-        strokeLinecap='round'
-        strokeLinejoin='round'
+        stroke-width='2'
+        stroke-linecap='round'
+        stroke-linejoin='round'
     />
 </svg>


### PR DESCRIPTION
Change svg attributes on add icon to be - separated from camel case. 