### PR TITLE
Hotfixes for Inline Edit

### DIFF
--- a/global/js/helpers/Card/cardThumbnail.js
+++ b/global/js/helpers/Card/cardThumbnail.js
@@ -37,7 +37,6 @@ export function CardThumbnail({
 }) {
   if (videoUrl) {
     const videoMedia = `
-        {/* Add a dark overlay over the image when used in Vertical Video Cards */}
         ${( size === "vertical-video" || size === "vertical-video-featured" ) ? `
           <div
             aria-hidden="true"

--- a/mysource_files/global/bundle.js
+++ b/mysource_files/global/bundle.js
@@ -84,7 +84,6 @@ import Z from"https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.mjs";cons
       ${e}
     </span>
   `}const l1={small:"su-left-13 su-bottom-13 [&>svg]:su-text-[4rem]",medium:"su-left-13 su-bottom-13 md:su-left-27 md:su-bottom-27 [&>svg]:su-text-[4rem] [&>svg]:md:su-text-[6rem]",large:"su-left-13 su-bottom-13 [&>svg]:su-text-[4rem]",featured:"su-left-13 su-bottom-13 md:su-left-27 md:su-bottom-27 [&>svg]:su-text-[4rem] [&>svg]:md:su-text-[6rem]","vertical-video":"su-left-32 su-bottom-34 sm:su-left-48 sm:su-bottom-61 lg:su-left-32 lg:su-bottom-34 2xl:su-left-48 2xl:su-bottom-61 [&>svg]:su-text-[6rem]","vertical-video-featured":"su-left-1/2 su-top-1/2 -su-translate-x-1/2 -su-translate-y-1/2 [&>svg]:su-text-[6rem]"};function je({imageUrl:e,alt:t="",aspectRatio:s,videoUrl:n,size:r="small",title:o="",videoIconClasses:a,uniqueId:i}){if(n){const l=`
-        {/* Add a dark overlay over the image when used in Vertical Video Cards */}
         ${r==="vertical-video"||r==="vertical-video-featured"?`
           <div
             aria-hidden="true"

--- a/packages/Header/header.hbs
+++ b/packages/Header/header.hbs
@@ -53,7 +53,9 @@
                     {{> header-search collection=search.collection profile=search.profile resultPage=search.resultPage}}
                 </div>
                 {{> header-site-logo url=url logo=logo logoLight=logoLight}}
-                {{> header-current-story-headline title=pageControls.title story=relatedStory contentType=pageControls.contentType}}
+                {{~#if pageControls.isStory~}}
+                    {{> header-current-story-headline title=pageControls.title story=relatedStory contentType=pageControls.contentType}}
+                {{~/if~}}
                 {{> header-preferences-tray audience=audience consent=consent}}
             </div>
             {{> header-main-nav items=navigation.major currentPage=pageControls.id}}

--- a/packages/Header/manifest.json
+++ b/packages/Header/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "header-component",
     "type": "edge",
-    "version": "6.0.0",
+    "version": "6.0.2",
     "namespace": "stanford-components",
     "description": "Stanford university Header component.",
     "displayName": "Header",

--- a/packages/combined-content-grid/manifest.json
+++ b/packages/combined-content-grid/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "combined-content-grid",
     "type": "edge",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "namespace": "stanford-components",
     "description": "A featured content grid combined with announcements and events",
     "displayName": "Combined content grid",

--- a/packages/featured-content-vv/main.js
+++ b/packages/featured-content-vv/main.js
@@ -51,7 +51,7 @@ export default {
         const { alignment = 'left' } = displayConfiguration || {};
 
         // NEW: Detect edit mode
-        const squizEdit = true || componentContext?.editor || false;
+        const squizEdit = componentContext?.editor || false;
         let squizEditTargets = null;
 
         if (squizEdit) {

--- a/packages/featured-content-vv/manifest.json
+++ b/packages/featured-content-vv/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "featured-content-vv",
     "type": "edge",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "namespace": "stanford-components",
     "description": "",
     "displayName": "Featured content with vertical video",

--- a/packages/featured-content/manifest.json
+++ b/packages/featured-content/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "featured-content",
     "type": "edge",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "namespace": "stanford-components",
     "description": "",
     "displayName": "Featured content",

--- a/packages/leadership-messages/manifest.json
+++ b/packages/leadership-messages/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "leadership-messages",
     "type": "edge",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "namespace": "stanford-components",
     "description": "Links to leadership messages displayed in a grid.",
     "displayName": "Leadership messages",

--- a/packages/multicolumn-listing/manifest.json
+++ b/packages/multicolumn-listing/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "multicolumn-listing",
     "type": "edge",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "namespace": "stanford-components",
     "description": "",
     "displayName": "Multicolumn listing",

--- a/packages/single-featured-content/manifest.json
+++ b/packages/single-featured-content/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "single-featured-content",
     "type": "edge",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "namespace": "stanford-components",
     "description": "Stanford university single featured content component",
     "displayName": "Single featured content",

--- a/packages/stories-carousel/manifest.json
+++ b/packages/stories-carousel/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "stories-carousel",
     "type": "edge",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "namespace": "stanford-components",
     "description": "Links to stories displayed as cards in a carousel.",
     "displayName": "Stories carousel",


### PR DESCRIPTION
# Summary

- Applies a fix to the header to remove the story headline H1 on non-story pages (it still remains on story pages).
- Applies a fix to the card video thumbnails to remove a stray comment

# Details

## Implementation details

Changes are all made to the component base.

## Deployment instructions

After merging, deploy the following components:
- Header
- featured-content
- featured-content-vv
- multicolumn-listing
- combined-content-grid
- single-featured-content
- stories-carousel
- leadership-messages

Set the latest versions of these components in the relevant component set. Then run the bulk upgrade tool.

# Validation instructions

Components have been tested in the PreProd test environment and are displaying as expected.
