### PR TITLE
SUP-122390: Refining cf-popular-stories results for accuracy with Cloudflare data

### DIFF
--- a/packages/popular-stories-cf/example-data/preview.data.json
+++ b/packages/popular-stories-cf/example-data/preview.data.json
@@ -1,9 +1,9 @@
 {
   "storiesCount": 5,
   "APIrespCount": 30,
-  "sourcePath": "/stories/%",
+  "sourcePath": "/stories/%/%/%",
   "assetExclusions": "",
   "contentTypeExclusions": "",
-  "APIdateRange": "1 month",
+  "APIdateRange": "1 week",
   "publishedDateMax": "Past 6 months"
 }

--- a/packages/popular-stories-cf/main.js
+++ b/packages/popular-stories-cf/main.js
@@ -144,6 +144,12 @@ export default {
                         AND: [
                             { clientRequestPath_like: "${sourcePath.trim()}" }
                             { clientRequestPath_notlike: "%/_admin%" }
+                            { clientRequestPath_notlike: "/stories/200%/%" }
+                            { clientRequestPath_notlike: "/stories/201%/%" }
+                            { clientRequestPath_notlike: "/stories/2020/%" }
+                            { clientRequestPath_notlike: "/stories/2021/%" }
+                            { clientRequestPath_notlike: "/stories/2022/%" }
+                            { clientRequestPath_notlike: "/stories/2023/%" }
                         ]
                         }
                         orderBy: [count_DESC]

--- a/packages/popular-stories-cf/main.js
+++ b/packages/popular-stories-cf/main.js
@@ -215,7 +215,6 @@ export default {
 
             data = await popularStoriesFetcher(
                 urls,
-                storiesCount,
                 exclusionContentTypes,
                 exclusionIDs,
                 dateRangeQuery,

--- a/packages/popular-stories-cf/main.js
+++ b/packages/popular-stories-cf/main.js
@@ -197,6 +197,7 @@ export default {
                 exclusionContentTypes,
                 exclusionIDs,
                 dateRangeQuery,
+                APIrespCount,
                 { FB_JSON_URL }
             );
         

--- a/packages/popular-stories-cf/manifest.json
+++ b/packages/popular-stories-cf/manifest.json
@@ -63,7 +63,7 @@
                         "title": "Source Path",
                         "description": "Input for the Cloudflare API to source data only from a certain path.",
                         "type": "string",
-                        "default": "/stories/%"
+                        "default": "/stories/%/%/%"
                     },
                     "APIrespCount": {
                         "title": "API Response Count",

--- a/packages/popular-stories-cf/manifest.json
+++ b/packages/popular-stories-cf/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "popular-stories-cf",
     "type": "edge",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "namespace": "stanford-components",
     "description": "Displays a list of popular stories.",
     "displayName": "Popular Stories",

--- a/packages/popular-stories-cf/scripts/popularStoriesHelpers.js
+++ b/packages/popular-stories-cf/scripts/popularStoriesHelpers.js
@@ -28,7 +28,7 @@ export async function popularStoriesFetcher(
     }
 
     adapter.url = `${FB_JSON_URL}?profile=stanford-report-push-search&collection=sug~sp-stanford-report-search&num_ranks=${
-        storiesCount + 15
+        storiesCount + 25
     }&query=[${assets.join(
         " "
     )}]&${dateRangeQuery}&query_not=[${exclusionContentTypes} ${exclusionIDs}]`;

--- a/packages/popular-stories-cf/scripts/popularStoriesHelpers.js
+++ b/packages/popular-stories-cf/scripts/popularStoriesHelpers.js
@@ -3,7 +3,6 @@ import { FetchAdapter } from "../../../global/js/utils/fetchAdapter";
  * Fetches popular stories from a Funnelback API based on provided URLs and filters.
  * @async
  * @param {string[]} urls - Array of URL paths to fetch stories for.
- * @param {number} storiesCount - The maximum number of stories to return.
  * @param {string} exclusionContentTypes - Space-separated list of content type IDs to exclude.
  * @param {string} exclusionIDs - Space-separated list of asset IDs to exclude.
  * @param {string} dateRangeQuery - Query string for date range filtering (e.g., "meta_d1=01Jan2023").
@@ -15,7 +14,6 @@ import { FetchAdapter } from "../../../global/js/utils/fetchAdapter";
  */
 export async function popularStoriesFetcher(
     urls,
-    storiesCount,
     exclusionContentTypes,
     exclusionIDs,
     dateRangeQuery,

--- a/packages/popular-stories-cf/scripts/popularStoriesHelpers.js
+++ b/packages/popular-stories-cf/scripts/popularStoriesHelpers.js
@@ -18,6 +18,7 @@ export async function popularStoriesFetcher(
     exclusionContentTypes,
     exclusionIDs,
     dateRangeQuery,
+    APIrespCount,
     { FB_JSON_URL }
 ) {
     const adapter = new FetchAdapter();
@@ -28,7 +29,7 @@ export async function popularStoriesFetcher(
     }
 
     adapter.url = `${FB_JSON_URL}?profile=stanford-report-push-search&collection=sug~sp-stanford-report-search&num_ranks=${
-        storiesCount + 25
+        APIrespCount
     }&query=[${assets.join(
         " "
     )}]&${dateRangeQuery}&query_not=[${exclusionContentTypes} ${exclusionIDs}]`;

--- a/packages/popular-stories-cf/scripts/popularStoriesHelpers.js
+++ b/packages/popular-stories-cf/scripts/popularStoriesHelpers.js
@@ -8,6 +8,7 @@ import { FetchAdapter } from "../../../global/js/utils/fetchAdapter";
  * @param {string} exclusionIDs - Space-separated list of asset IDs to exclude.
  * @param {string} dateRangeQuery - Query string for date range filtering (e.g., "meta_d1=01Jan2023").
  * @param {Object} options - Configuration options.
+ * @param {number} APIrespCount - Number of results to request from Cloudflare Analytics API used to define num_ranks in Funnelback query.
  * @param {string} options.FB_JSON_URL - The base URL for the Funnelback JSON API.
  * @returns {Promise<Object[]|undefined>} Array of story results from Funnelback, or undefined if fetch fails.
  * @throws {Error} If the fetch request fails.


### PR DESCRIPTION
# Summary

These changes address recent reports of low traffic/new stories making it into the top 5 displayed on page via the cf-popular-stories module.

# Details

## Implementation details

This PR includes three improvements to ensure accurate story selection and proper filtering using the `cf-popular-stories` component:

**1. Updated Default Source Path**
Changed the default `sourcePath` value to `/stories/%/%/%` to properly filter Cloudflare Analytics requests to only include story pages with date paths. This excludes date-only paths (like `/stories/2024/01`) and ensures we're only analyzing traffic to actual story content pages.

**2. Added Year-Based Exclusions**
Added exclusions to filter out stories from older years (2000-2023) in the Cloudflare Analytics query. This prevents outdated content from appearing in popular stories and ensures the component focuses on recent, relevant content. **_Note:_** This may need to be updated yearly to exclude years prior to the max publish date. For example, 2024 will need to be added to the query exclusions in January of 2027.

**3. Increased Funnelback Result Limit**
Adjust `num_ranks` parameter in the Funnelback query from `storiesCount + 15` to instead use the `APIrespCount` component variable directly. This matches the total number of results returned by Cloudflare and ensures Funnelback returns enough results to match all Cloudflare URLs in popularity order, accounting for stories that may be filtered out by date range or content type exclusions. Without this buffer, some popular stories from Cloudflare Analytics were not appearing in the final results because Funnelback wasn't returning enough matches.

## Deployment instructions

The component will need to be deployed to dev to upgrade the active version to `6.0.2`, and the Source Path value for this in the global matrix configurations (for both dev and production) will need to be updated to `/stories/%/%/%`. After testing and confirmation, the same process will need to take place in production

# Validation instructions

1. Run this branch locally
2. Import this collection in Postman and run the `POST` to Cloudflare (you may need to update the date/time graphQL variables in the body tab): [Stanford.postman_collection.json](https://github.com/user-attachments/files/24870509/Stanford.postman_collection.json)
3. Ensure that the top 5 results (per Cloudflare) that meet the criteria of the component fields/variables defined in preview.data.json appear on page at [http://localhost:5555/dev/render/stanford-development__popular-stories-cf__6.0.2?_previewKey=default](http://localhost:5555/dev/render/stanford-development__popular-stories-cf__6.0.2?_previewKey=default)

# References

## JIRA
[https://squizgroup.atlassian.net/browse/SUP-122390](https://squizgroup.atlassian.net/browse/SUP-122390)