### PR TITLE
fix - SUP-122127

### DIFF
--- a/global/hbs/partials/card-thumbnail/card-thumbnail.hbs
+++ b/global/hbs/partials/card-thumbnail/card-thumbnail.hbs
@@ -1,5 +1,5 @@
 {{~#if videoUrl~}}
-<button class="su-z-100 su-component-card-thumbnail su-group su-block su-relative su-size-full" type="button" aria-haspopup="dialog" data-click="open-modal" data-modal-id="{{uniqueID}}">
+<button class="su-z-10 su-component-card-thumbnail su-group su-block su-relative su-size-full" type="button" aria-haspopup="dialog" data-click="open-modal" data-modal-id="{{uniqueID}}">
     {{#> media-ratio imageUrl=imageUrl imageAlt=imageAlt aspectRatio=aspectRatio squizEdit=squizEdit rounded=rounded}}
         {{~#ifEquals aspectRatio "vertical-video"}}
             <div aria-hidden="true" class="su-absolute su-inset-0 su-bg-gradient-to-t su-from-black-true/80 su-via-80% su-via-black-true/10 su-pointer-events-none su-z-20"

--- a/packages/combined-content-grid/manifest.json
+++ b/packages/combined-content-grid/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "combined-content-grid",
     "type": "edge",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "namespace": "stanford-components",
     "description": "A featured content grid combined with announcements and events",
     "displayName": "Combined content grid",

--- a/packages/topic-subtopic-listing/manifest.json
+++ b/packages/topic-subtopic-listing/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "topic-subtopic-listing",
     "type": "edge",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "namespace": "stanford-components",
     "description": "Listing of stories as cards with pagination.",
     "displayName": "Topic / subtopic listing",


### PR DESCRIPTION
# Summary
Fix video modal not opening when clicking the video thumbnail on the large (featured) card in the Combined Content Grid component. The click was navigating to the story page instead of opening the video modal.

__Merge by *date*__

# Details

## Implementation details

The `card-thumbnail.hbs` shared partial used the Tailwind class `su-z-100` on the video thumbnail `<button>`. However, `su-z-100` is not a valid utility in the project's Tailwind configuration (the default scale only goes up to `z-50`), so it generated no CSS.

The `su-stretched-link` on the card's heading `<a>` tag creates an `::after` pseudo-element with `z-index: 1` that covers the entire card. Without a z-index on the button, this pseudo-element sat above it and intercepted all clicks, causing navigation to the story page instead of triggering the modal.

The fix changes `su-z-100` to `su-z-10` (which generates `z-index: 10`) so the button sits above the stretched link's overlay. This aligns the Handlebars partial with the equivalent JS helper (`CardThumbnail` in `cardThumbnail.js`), which already uses `su-z-10` and works correctly in the Single Featured Content component.

### Components affected

This is a shared partial (`global/hbs/partials/card-thumbnail/card-thumbnail.hbs`), used by many other partials.
Components affected by this change:
- combined-content-grid 
- topic-subtopic-listing 

Components horizontal-video-testimonials, featured-content-vv also use this card but will be unaffected by the change as the css class addition won't have an effect on the current css configuration. 

Non-video cards are unaffected as they use the `<div>` branch of the partial, not the `<button>` branch.

## Deployment instructions

1. Run `npm run build` to rebuild all components (the HBS partial is precompiled into each component's `dist/main.js`).
2. Deploy the rebuilt components to DXP Edge.
3. No git bridge update needed — `bundle.css` already contains `su-z-10` and `bundle.js` is unchanged.

# Validation instructions

1. Navigate to a page with the Combined Content Grid component where the featured (large) card has a video type story (look for the play icon overlay on the thumbnail).
2. Click the video thumbnail image.
3. **Expected:** A modal opens with the embedded YouTube video playing.
4. **Previously:** Clicking the thumbnail navigated to the story page.
5. Verify the modal close button (X), clicking outside the modal, and pressing Escape all dismiss the modal.
6. Verify that non-video cards in the grid still navigate to their story pages normally.
7. Repeat validation on any other component using video card thumbnails (e.g., featured-content, horizontal video cards) to confirm no regressions.

# References

## JIRA
https://squizgroup.atlassian.net/browse/SUP-122127

## PRs

## Other
