### PR TITLE
SUP-128809: Fix orientation issues with Image Gallery w/ Modal Component

### DIFF
--- a/global/js/utils/formatCardDataImage/formatCardDataImage.js
+++ b/global/js/utils/formatCardDataImage/formatCardDataImage.js
@@ -20,6 +20,11 @@ export function formatCardDataImage({ attributes, url }) {
         return Number.isFinite(num) ? num : undefined;
     };
 
+    const toPositiveNumber = (value) => {
+        const num = toFiniteNumber(value);
+        return num && num > 0 ? num : undefined;
+    };
+
     const inferDimsFromUrl = (rawUrl) => {
         if (!rawUrl || typeof rawUrl !== "string") return {};
 
@@ -37,11 +42,31 @@ export function formatCardDataImage({ attributes, url }) {
         const match = rawUrl.match(/\/(\d{2,5})\/(\d{2,5})(?:\/|$|\?)/);
         if (!match) return {};
 
-        const w = toFiniteNumber(match[1]);
-        const h = toFiniteNumber(match[2]);
+        const w = toPositiveNumber(match[1]);
+        const h = toPositiveNumber(match[2]);
         if (w && h) return { width: w, height: h };
 
         return {};
+    };
+
+    const inferDimsFromVarieties = (attrs) => {
+        // Matrix sometimes stores the real dimensions only on image varieties.
+        const varieties = normalizeAttrValue(attrs?.varieties);
+        const data = normalizeAttrValue(varieties?.data);
+        if (!data || typeof data !== "object") return {};
+
+        let best = null;
+        for (const key of Object.keys(data)) {
+            const v = data[key];
+            const w = toPositiveNumber(v?.variety_width ?? v?.varietyWidth ?? v?.width);
+            const h = toPositiveNumber(v?.variety_height ?? v?.varietyHeight ?? v?.height);
+            if (!w || !h) continue;
+            const area = w * h;
+            if (!best || area > best.area) best = { width: w, height: h, area };
+        }
+
+        if (!best) return {};
+        return { width: best.width, height: best.height };
     };
 
     const alt = normalizeAttrValue(attributes?.alt) ?? "";
@@ -49,21 +74,22 @@ export function formatCardDataImage({ attributes, url }) {
     const embedded = normalizeAttrValue(attributes?.embedded_data);
 
     const width =
-        toFiniteNumber(attributes?.width) ??
-        toFiniteNumber(embedded?.imagewidth) ??
-        toFiniteNumber(embedded?.ImageWidth);
+        toPositiveNumber(attributes?.width) ??
+        toPositiveNumber(embedded?.imagewidth) ??
+        toPositiveNumber(embedded?.ImageWidth);
 
     const height =
-        toFiniteNumber(attributes?.height) ??
-        toFiniteNumber(embedded?.imageheight) ??
-        toFiniteNumber(embedded?.ImageHeight);
+        toPositiveNumber(attributes?.height) ??
+        toPositiveNumber(embedded?.imageheight) ??
+        toPositiveNumber(embedded?.ImageHeight);
 
-    const inferred = inferDimsFromUrl(url);
-    const resolvedWidth = width ?? inferred.width;
-    const resolvedHeight = height ?? inferred.height;
+    const inferredVarieties = inferDimsFromVarieties(attributes);
+    const inferredUrl = inferDimsFromUrl(url);
 
-    // Default to horizontal when dimensions are unknown. This prevents
-    // "everything becomes vertical" failures when upstream data omits dims.
+    const resolvedWidth = width ?? inferredVarieties.width ?? inferredUrl.width;
+    const resolvedHeight = height ?? inferredVarieties.height ?? inferredUrl.height;
+
+    // Default to horizontal when dimensions are unknown.
     const orientation =
         resolvedWidth && resolvedHeight
             ? (resolvedWidth >= resolvedHeight ? "h" : "v")

--- a/global/js/utils/formatCardDataImage/formatCardDataImage.js
+++ b/global/js/utils/formatCardDataImage/formatCardDataImage.js
@@ -8,14 +8,71 @@
  * @returns {object}
  */
 export function formatCardDataImage({ attributes, url }) {
-    const { alt, width, height } = attributes;
-  
-    const orientation = width >= height ? "h" : "v";
-  
+    const normalizeAttrValue = (attr) => {
+        if (attr == null) return undefined;
+        if (typeof attr === "object" && "value" in attr) return attr.value;
+        return attr;
+    };
+
+    const toFiniteNumber = (value) => {
+        const normalized = normalizeAttrValue(value);
+        const num = typeof normalized === "number" ? normalized : Number(normalized);
+        return Number.isFinite(num) ? num : undefined;
+    };
+
+    const inferDimsFromUrl = (rawUrl) => {
+        if (!rawUrl || typeof rawUrl !== "string") return {};
+
+        // Query param patterns (?w=1200&h=400, ?width=1200&height=400)
+        try {
+            const parsed = new URL(rawUrl);
+            const w = toFiniteNumber(parsed.searchParams.get("w") ?? parsed.searchParams.get("width"));
+            const h = toFiniteNumber(parsed.searchParams.get("h") ?? parsed.searchParams.get("height"));
+            if (w && h) return { width: w, height: h };
+        } catch {
+            // ignore invalid URLs
+        }
+
+        // Common path pattern (e.g. https://picsum.photos/1200/400)
+        const match = rawUrl.match(/\/(\d{2,5})\/(\d{2,5})(?:\/|$|\?)/);
+        if (!match) return {};
+
+        const w = toFiniteNumber(match[1]);
+        const h = toFiniteNumber(match[2]);
+        if (w && h) return { width: w, height: h };
+
+        return {};
+    };
+
+    const alt = normalizeAttrValue(attributes?.alt) ?? "";
+
+    const embedded = normalizeAttrValue(attributes?.embedded_data);
+
+    const width =
+        toFiniteNumber(attributes?.width) ??
+        toFiniteNumber(embedded?.imagewidth) ??
+        toFiniteNumber(embedded?.ImageWidth);
+
+    const height =
+        toFiniteNumber(attributes?.height) ??
+        toFiniteNumber(embedded?.imageheight) ??
+        toFiniteNumber(embedded?.ImageHeight);
+
+    const inferred = inferDimsFromUrl(url);
+    const resolvedWidth = width ?? inferred.width;
+    const resolvedHeight = height ?? inferred.height;
+
+    // Default to horizontal when dimensions are unknown. This prevents
+    // "everything becomes vertical" failures when upstream data omits dims.
+    const orientation =
+        resolvedWidth && resolvedHeight
+            ? (resolvedWidth >= resolvedHeight ? "h" : "v")
+            : "h";
+
     return {
         alt,
-        width,
-        height,
+        width: resolvedWidth,
+        height: resolvedHeight,
         url,
         orientation,
     };

--- a/global/js/utils/formatCardDataImage/formatCardDataImage.spec.js
+++ b/global/js/utils/formatCardDataImage/formatCardDataImage.spec.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { formatCardDataImage } from "./formatCardDataImage";
+
+describe("[formatCardDataImage]", () => {
+  it("extracts dimensions from Matrix attribute objects", () => {
+    const result = formatCardDataImage({
+      url: "https://example.test/image.jpg",
+      attributes: {
+        alt: { value: "Alt text" },
+        width: { value: "1500" },
+        height: { value: "1000" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      alt: "Alt text",
+      width: 1500,
+      height: 1000,
+      orientation: "h",
+    });
+  });
+
+  it("falls back to embedded EXIF-like dimensions when present", () => {
+    const result = formatCardDataImage({
+      url: "https://example.test/image.jpg",
+      attributes: {
+        embedded_data: {
+          value: {
+            imagewidth: { value: "800" },
+            imageheight: { value: "1200" },
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      width: 800,
+      height: 1200,
+      orientation: "v",
+    });
+  });
+
+  it("infers dimensions from common URL patterns when attributes are missing", () => {
+    const result = formatCardDataImage({
+      url: "https://picsum.photos/1200/400",
+      attributes: {},
+    });
+
+    expect(result).toMatchObject({
+      width: 1200,
+      height: 400,
+      orientation: "h",
+    });
+  });
+
+  it("falls back to varieties when width/height are missing or zero", () => {
+    const result = formatCardDataImage({
+      url: "https://example.test/image.jpg",
+      attributes: {
+        width: { value: "0" },
+        height: { value: "0" },
+        varieties: {
+          value: {
+            data: {
+              v1: { variety_width: 100, variety_height: 100 },
+              v2: { variety_width: 1500, variety_height: 1000 },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      width: 1500,
+      height: 1000,
+      orientation: "h",
+    });
+  });
+});
+

--- a/packages/image-gallery-modal/manifest.json
+++ b/packages/image-gallery-modal/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "image-gallery-modal",
     "type": "edge",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "namespace": "stanford-components",
     "description": "An image gallery that opens in a modal.",
     "displayName": "Image gallery with modal",

--- a/packages/image-gallery-modal/manifest.json
+++ b/packages/image-gallery-modal/manifest.json
@@ -2,7 +2,7 @@
     "$schema": "http://localhost:3000/schemas/v1.json#",
     "name": "image-gallery-modal",
     "type": "edge",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "namespace": "stanford-components",
     "description": "An image gallery that opens in a modal.",
     "displayName": "Image gallery with modal",


### PR DESCRIPTION
# Summary
Bug reported where image gallery component displaying preview as 4 vertical images, as opposed to two square images with one vertical image to view the rest of the gallery. The root cause of this issue is as follows:

`image-gallery-modal` relies on formatCardDataImage() to set each image’s orientation (h vs v). The Matrix images API returns attributes.width / attributes.height as objects (e.g. { value: "1500" }), but our formatter treated them like numbers, so the comparison failed and everything got classified as vertical, producing the wrong mosaic preview.

# Details

## Implementation details

The issue was caused by how we were determining whether each image was “horizontal” or “vertical” for the gallery mosaic preview. The image-gallery-modal component relies on formatCardDataImage() to read an image’s width and height from the Matrix API response and then set an orientation flag (h vs v). In this story’s case, the Matrix image endpoint was returning width and height in a different shape than we assumed (often as objects like { value: "1500" }, and sometimes with dimensions only available in embedded metadata), so the old code wasn’t reliably getting numeric dimensions. That made the orientation calculation fail and effectively classify images as vertical, which is why a mixed set of two horizontals followed by a vertical was previewing as all vertical tiles. The fix makes the formatter more defensive: it normalizes Matrix attribute values, safely converts them to numbers, falls back to embedded dimension fields when present, and (as a last resort) can infer dimensions from common URL patterns. With accurate dimensions restored, the mosaic preview now correctly reflects the intended horizontal/vertical layout.

## Deployment instructions

The component will need to be deployed to dev to upgrade the active version to 6.0.1 to verify changes, then upgraded to this same version of the component in the prod component set.

# Validation instructions

Go to ____ and confirm that the orientation meets the standard for the "correct" version of the gallery layout as noted within the ticket above

# References

## JIRA
[* _Link to ticket_](https://squizgroup.atlassian.net/browse/SUP-128809)

## PRs
N/A